### PR TITLE
Add option to construct XML with cdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 clover.xml
 composer.lock
 phpunit.xml
+phpcs.xml

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,14 +3,12 @@ filter:
         - 'vendor/*'
 before_commands:
     - 'composer install --prefer-source'
-build:
-    tests:
-        override:
-            - php-scrutinizer-run
-            - phpcs-run --standard=./vendor/chadicus/coding-standard/Chadicus/ruleset.xml
 tools:
     php_analyzer: true
     php_mess_detector: true
+    php_code_sniffer:
+        config:
+            standard: PSR2
     sensiolabs_security_checker: true
     php_loc:
         excluded_dirs:
@@ -21,4 +19,4 @@ build_failure_conditions:
     - 'elements.rating(< B).new.exists'
     - 'issues.label("coding-style").new.exists'
     - 'issues.severity(>= MAJOR).new.exists'
-    - 'project.metric("scrutinizer.quality", < 9)'
+    - 'project.metric("scrutinizer.quality", < 6)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ matrix:
 before_script:
   - composer update $PREFER_LOWEST
 script: ./vendor/bin/phpunit
-after_success: ./vendor/bin/coveralls -v
+after_success: ./vendor/bin/php-coveralls -v

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SubjectivePHP\DOM
 
-[![Build Status](https://travis-ci.org/subjective-php/dom-php.svg?branch=master)](https://travis-ci.org/subjective-php/dom-php)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/subjective-php/dom-php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/subjective-php/dom-php/?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/subjective-php/dom-php/badge.svg?branch=master)](https://coveralls.io/github/subjective-php/dom-php?branch=master)
+[![Build Status](https://travis-ci.org/subjective-php/dom.svg?branch=master)](https://travis-ci.org/subjective-php/dom)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/subjective-php/dom/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/subjective-php/dom/?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/subjective-php/dom/badge.svg?branch=master)](https://coveralls.io/github/subjective-php/dom?branch=master)
 
 [![Latest Stable Version](https://poser.pugx.org/subjective-php/dom/v/stable)](https://packagist.org/packages/subjective-php/dom)
 [![Latest Unstable Version](https://poser.pugx.org/subjective-php/dom/v/unstable)](https://packagist.org/packages/subjective-php/dom)
@@ -30,8 +30,8 @@ composer require subjective-php/dom
 ##Contact
 Developers may be contacted at:
 
- * [Pull Requests](https://github.com/subjective-php/dom-php/pulls)
- * [Issues](https://github.com/subjective-php/dom-php/issues)
+ * [Pull Requests](https://github.com/subjective-php/dom/pulls)
+ * [Issues](https://github.com/subjective-php/dom/issues)
 
 ##Run Unit Tests
 With a checkout of the code get [Composer](http://getcomposer.org) in your PATH and run:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://travis-ci.org/subjective-php/dom-php.svg?branch=master)](https://travis-ci.org/subjective-php/dom-php)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/subjective-php/dom-php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/subjective-php/dom-php/?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/subjective-php/dom-php/badge.svg?branch=master)](https://coveralls.io/github/subjective-php/dom-php?branch=master)
-[![Dependency Status](https://www.versioneye.com/user/projects/55fdfd99601dd9001f000001/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/55fdfd99601dd9001f000001)
 
 [![Latest Stable Version](https://poser.pugx.org/subjective-php/dom/v/stable)](https://packagist.org/packages/subjective-php/dom)
 [![Latest Unstable Version](https://poser.pugx.org/subjective-php/dom/v/unstable)](https://packagist.org/packages/subjective-php/dom)

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         "ext-dom": "*"
     },
     "require-dev": {
-        "chadicus/coding-standard": "^1.3",
         "php-coveralls/php-coveralls": "^1.0",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.0",
+        "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {
         "psr-4": { "SubjectivePHP\\Util\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-dom": "*"
     },
     "require-dev": {
-        "php-coveralls/php-coveralls": "^1.0",
+        "php-coveralls/php-coveralls": "^2.1",
         "phpunit/phpunit": "^6.0",
         "squizlabs/php_codesniffer": "^3.2"
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<ruleset name="PHP_CodeSniffer">
-    <file>.</file>
-    <exclude-pattern>*/vendor/*</exclude-pattern>
-    <arg value="np" />
-    <rule ref="./vendor/chadicus/coding-standard/Chadicus"/>
-</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+    <file>src</file>
+    <file>tests</file>
+    <arg name="colors" />
+    <arg value="p" />
+    <rule ref="PSR2" />
+</ruleset>

--- a/src/DOMDocument.php
+++ b/src/DOMDocument.php
@@ -81,7 +81,7 @@ abstract class DOMDocument
         }
 
         $pointer->appendChild(
-           $pointer->ownerDocument->createCDATASection($value)
+            $pointer->ownerDocument->createCDATASection($value)
         );
     }
 

--- a/tests/DOMDocumentTest.php
+++ b/tests/DOMDocumentTest.php
@@ -31,6 +31,20 @@ final class DOMDocumentTest extends TestCase
     }
 
     /**
+     * @test
+     * @covers ::fromArray
+     */
+    public function fromArrayUseCdata()
+    {
+        $document = DOMDocument::fromArray(include __DIR__ . '/_files/simple.php', ['use_cdata' => true]);
+        $document->formatOutput = true;
+        $this->assertSame(
+            file_get_contents(__DIR__ . '/_files/simple_cdata.xml'),
+            $document->saveXml()
+        );
+    }
+
+    /**
      * Verify behavior of fromArray() with a more complex structure.
      *
      * @test

--- a/tests/DOMDocumentTest.php
+++ b/tests/DOMDocumentTest.php
@@ -169,6 +169,23 @@ XML;
     }
 
     /**
+     * @test
+     * @covers ::addXPath
+     */
+    public function addXPathIgnoresCDataWitAttribute()
+    {
+        $xpath = '/path/to/node/with/@attribute';
+        $document = new \DOMDocument();
+        DOMDocument::addXPath($document, $xpath, 'value', true);
+        $expected = <<<XML
+<?xml version="1.0"?>
+<path><to><node><with attribute="value"/></node></to></path>
+
+XML;
+        $this->assertSame($expected, $document->saveXml());
+    }
+
+    /**
      * Verify basic behavior of addXPath().
      *
      * @test
@@ -184,6 +201,23 @@ XML;
         $expected = <<<XML
 <?xml version="1.0"?>
 <path><to><node>value</node></to></path>
+
+XML;
+        $this->assertSame($expected, $document->saveXml());
+    }
+
+    /**
+     * @test
+     * @covers ::addXPath
+     */
+    public function addXPathWithCData()
+    {
+        $xpath = '/path/to/node';
+        $document = new \DOMDocument();
+        DOMDocument::addXPath($document, $xpath, 'value', true);
+        $expected = <<<XML
+<?xml version="1.0"?>
+<path><to><node><![CDATA[value]]></node></to></path>
 
 XML;
         $this->assertSame($expected, $document->saveXml());

--- a/tests/_files/simple_cdata.xml
+++ b/tests/_files/simple_cdata.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<catalog>
+  <book id="bk101">
+    <author><![CDATA[Gambardella, Matthew]]></author>
+    <title><![CDATA[XML Developer's Guide]]></title>
+    <genre><![CDATA[Computer]]></genre>
+    <price><![CDATA[44.95]]></price>
+    <publish_date><![CDATA[2000-10-01]]></publish_date>
+    <description><![CDATA[An in-depth look at creating applications with XML.]]></description>
+  </book>
+  <book id="bk102">
+    <author><![CDATA[Ralls, Kim]]></author>
+    <title><![CDATA[Midnight Rain]]></title>
+    <genre><![CDATA[Fantasy]]></genre>
+    <price><![CDATA[5.95]]></price>
+    <publish_date><![CDATA[2000-12-16]]></publish_date>
+    <description><![CDATA[A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.]]></description>
+  </book>
+  <book id="bk103">
+    <author><![CDATA[Corets, Eva]]></author>
+    <title><![CDATA[Maeve Ascendant]]></title>
+    <genre><![CDATA[Fantasy]]></genre>
+    <price><![CDATA[5.95]]></price>
+    <publish_date><![CDATA[2000-11-17]]></publish_date>
+    <description><![CDATA[After the collapse of a nanotechnology society in England, the young survivors lay the foundation for a new society.]]></description>
+  </book>
+</catalog>


### PR DESCRIPTION
#### What does this PR do?
This pull request adds a `useCdata` flag to `addXPath`. If true it will create elements with values wrapped with `<![CDATA[]]>` tags.  This option can be passed into `fromArray` in the new `$options` array like so `['use_cdata' => true]`
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
