### PR TITLE
add support for php 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ clover.xml
 composer.lock
 phpunit.xml
 phpcs.xml
+.*
+!.github
+!.coveralls.yml
+!.travis.yml
+!.scrutinizer.yml
+!.gitattributes
+!.gitignore

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,13 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.0",
+        "php": "^7.0||^8.0",
         "ext-dom": "*"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.1",
-        "phpunit/phpunit": "^6.0",
-        "squizlabs/php_codesniffer": "^3.2"
+        "phpunit/phpunit": ">=6.0",
+        "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload": {
         "psr-4": { "SubjectivePHP\\Util\\": "src/" }

--- a/tests/DOMDocumentTest.php
+++ b/tests/DOMDocumentTest.php
@@ -67,13 +67,11 @@ final class DOMDocumentTest extends TestCase
      *
      * @test
      * @covers ::addXPath
-     * @expectedException \DOMException
-     * @expectedExceptionMessage XPath [1]/foo is not valid.
-     *
-     * @return void
      */
     public function addXPathInvalidExpression()
     {
+        $this->expectExceptionMessage("XPath [1]/foo is not valid.");
+        $this->expectException(\DOMException::class);
         DOMDocument::addXPath(new \DOMDocument(), '[1]/foo');
     }
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds support for PHP 8.
Maintains backwards compatibility
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
