### PR TITLE
Add support for PHP 8

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ clover.xml
 composer.lock
 phpunit.xml
 phpcs.xml
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.0",
+        "php": "^7.0 || ^8.0",
         "ext-dom": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-dom": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": ">=6.5",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {

--- a/tests/DOMDocumentTest.php
+++ b/tests/DOMDocumentTest.php
@@ -1,12 +1,11 @@
 <?php
 namespace SubjectivePHPTest\DOM;
 
+use DOMException;
 use SubjectivePHP\Util\DOMDocument;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Unit tests for the \SubjectivePHP\Util\DOMDocument class.
- *
  * @coversDefaultClass \SubjectivePHP\Util\DOMDocument
  * @covers ::<private>
  */
@@ -67,13 +66,13 @@ final class DOMDocumentTest extends TestCase
      *
      * @test
      * @covers ::addXPath
-     * @expectedException \DOMException
-     * @expectedExceptionMessage XPath [1]/foo is not valid.
      *
      * @return void
      */
     public function addXPathInvalidExpression()
     {
+        $this->expectException(DOMException::class);
+        $this->expectExceptionMessage('XPath [1]/foo is not valid');
         DOMDocument::addXPath(new \DOMDocument(), '[1]/foo');
     }
 


### PR DESCRIPTION
#### What does this PR do?
* Allow for newer versions of PHPUnit
* Allow PHP >= 8.0
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
